### PR TITLE
feat: add error handling plugin for `@pinia/colada` queries

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ loadMessages(locale).then(messages => {
 	const i18n = setupI18n(locale, messages ?? {});
 
 	const app = createApp(App);
-	app.use(router).use(pinia).use(piniaColadaPlugin).use(i18n);
+	app.use(router).use(pinia).use(i18n).use(piniaColadaPlugin, i18n);
 
 	const userStore = useUserStore();
 

--- a/src/mutations/category.ts
+++ b/src/mutations/category.ts
@@ -9,6 +9,7 @@ import { useSnackbarStore } from '@/stores/snackbar';
 import { defineMutation, useMutation, useQueryCache } from '@pinia/colada';
 import { useI18n } from 'vue-i18n';
 import { v4 as uuidV4 } from 'uuid';
+import { categoriesQuery } from '@/queries/category';
 
 export const useCreateCategory = defineMutation(() => {
 	const { t, te } = useI18n();
@@ -146,33 +147,40 @@ export const useDeleteCategory = defineMutation(() => {
 	return useMutation({
 		mutation: apiDeleteCategoryById,
 		onMutate: categoryId => {
+			const categoriesQueryKey = categoriesQuery.key;
 			// save the old value of categories
-			const oldCategories = queryCache.getQueryData<Category[]>(['categories']);
+			const oldCategories = queryCache.getQueryData(categoriesQueryKey);
 
 			// create a new array without the deleted category
 			const newCategories = oldCategories?.filter(cat => cat.id !== categoryId);
 
 			// update the cache with the new categories
-			queryCache.setQueryData(['categories'], newCategories);
+			if (newCategories) {
+				queryCache.setQueryData(categoriesQueryKey, newCategories);
+			}
 
 			// we cancel (without refetching) all queries that depend on the categories
 			// to prevent them from updating the cache with an outdated value
-			queryCache.cancelQueries({ key: ['categories'] });
+			queryCache.cancelQueries({ key: categoriesQueryKey, exact: true });
 
 			// pass the old & new categories to the other hooks
 			// to handle rollback
 			return { oldCategories, newCategories };
 		},
 		onSettled() {
+			const categoriesQueryKey = categoriesQuery.key;
+
 			// invalidate the query to refetch the new data
-			queryCache.invalidateQueries({ key: ['categories'] });
+			queryCache.invalidateQueries({ key: categoriesQueryKey, exact: true });
 		},
 		onError: (error, categoryId, { newCategories, oldCategories }) => {
+			const categoriesQueryKey = categoriesQuery.key;
+
 			// before applying the rollback, we need to check if the value in the cache
 			// is the same because the cache could have been updated by another mutation
 			// or query
-			if (newCategories === queryCache.getQueryData(['categories'])) {
-				queryCache.setQueryData(['categories'], oldCategories);
+			if (oldCategories && newCategories === queryCache.getQueryData(categoriesQueryKey)) {
+				queryCache.setQueryData(categoriesQueryKey, oldCategories);
 			}
 
 			// handle the error

--- a/src/plugins/pinia-colada.ts
+++ b/src/plugins/pinia-colada.ts
@@ -1,8 +1,39 @@
 import type { Plugin } from 'vue';
-import { PiniaColada } from '@pinia/colada';
+import { PiniaColada, type PiniaColadaPlugin } from '@pinia/colada';
+import { useSnackbarStore } from '@/stores/snackbar';
+import type { I18n } from 'vue-i18n';
 
-const piniaColadaPlugin: Plugin = {
-	install(app) {
+const PiniaColadaQueryErrorHandlingPlugin = (i18n: I18n): PiniaColadaPlugin => {
+	return ({ queryCache, pinia }) => {
+		const { showMessage } = useSnackbarStore(pinia);
+		const { t, te } = i18n.global;
+
+		queryCache.$onAction(({ name, args, onError }) => {
+			if (name === 'fetch') {
+				const [entry] = args;
+				onError(error => {
+					if (!(error instanceof Error)) {
+						return;
+					}
+
+					const metaErrorMessage =
+						typeof entry.meta.errorMessage === 'function'
+							? entry.meta.errorMessage(error)
+							: entry.meta.errorMessage;
+					const message =
+						metaErrorMessage ||
+						// @ts-expect-error - Too difficult to type this correctly, we can ignore it for now
+						(te(`warnings.${error.message}`) ? t('$vuetify.badge') : error.message);
+
+					showMessage(message, 'red-darken-3');
+				});
+			}
+		});
+	};
+};
+
+const piniaColadaPlugin: Plugin<I18n> = {
+	install(app, i18n) {
 		app.use(PiniaColada, {
 			queryOptions: {
 				// change the stale time for all queries
@@ -12,9 +43,7 @@ const piniaColadaPlugin: Plugin = {
 			mutationOptions: {
 				// add global mutation options here
 			},
-			plugins: [
-				// add Pinia Colada plugins here
-			],
+			plugins: [PiniaColadaQueryErrorHandlingPlugin(i18n)],
 		});
 	},
 };

--- a/src/plugins/pinia-colada.ts
+++ b/src/plugins/pinia-colada.ts
@@ -23,7 +23,7 @@ const PiniaColadaQueryErrorHandlingPlugin = (i18n: I18n): PiniaColadaPlugin => {
 					const message =
 						metaErrorMessage ||
 						// @ts-expect-error - Too difficult to type this correctly, we can ignore it for now
-						(te(`warnings.${error.message}`) ? t('$vuetify.badge') : error.message);
+						(te(`warnings.${error.message}`) ? t(`warnings.${error.message}`) : error.message);
 
 					showMessage(message, 'red-darken-3');
 				});

--- a/src/plugins/pinia-colada.ts
+++ b/src/plugins/pinia-colada.ts
@@ -11,9 +11,14 @@ const PiniaColadaQueryErrorHandlingPlugin = (i18n: I18n): PiniaColadaPlugin => {
 		queryCache.$onAction(({ name, args, onError }) => {
 			if (name === 'fetch') {
 				const [entry] = args;
+
 				onError(error => {
 					if (!(error instanceof Error)) {
 						return;
+					}
+
+					if (entry.meta.onError && typeof entry.meta.onError === 'function') {
+						entry.meta.onError(error, entry);
 					}
 
 					const metaErrorMessage =

--- a/src/queries/category.ts
+++ b/src/queries/category.ts
@@ -1,47 +1,37 @@
 import { fetchCategories, fetchCategoriesSpendStats } from '@/api/category';
-import { useSnackbarStore } from '@/stores/snackbar';
-import { defineQuery, useQuery } from '@pinia/colada';
-import { watch } from 'vue';
+import { defineQuery, defineQueryOptions, useQuery, useQueryState } from '@pinia/colada';
 import { useI18n } from 'vue-i18n';
+
+export const categoriesQuery = defineQueryOptions({
+	key: ['categories'],
+	query: fetchCategories,
+});
 
 export const useCategoriesQuery = defineQuery(() => {
 	const { t, te } = useI18n({ useScope: 'global' });
-	const { showMessage } = useSnackbarStore();
 
-	const query = useQuery({
-		key: ['categories'],
-		query: fetchCategories,
-	});
-
-	watch(query.error, e => {
-		if (e) {
-			showMessage(
+	return useQuery({
+		...categoriesQuery,
+		meta: {
+			errorMessage: e =>
 				te(`warnings.${e.message}`) ? t(`warnings.${e.message}`) : t('error_load_categories'),
-				'red-darken-3'
-			);
-		}
+		},
 	});
+});
 
-	return query;
+export function useCategoriesQueryState() {
+	return useQueryState(categoriesQuery.key);
+}
+
+export const categoriesSpendStatsQuery = defineQueryOptions({
+	key: ['catStats'],
+	query: fetchCategoriesSpendStats,
 });
 
 export const useCategoriesSpendStatsQuery = defineQuery(() => {
-	const { te, t } = useI18n({ useScope: 'global' });
-	const { showMessage } = useSnackbarStore();
-
-	const query = useQuery({
-		key: ['catStats'],
-		query: fetchCategoriesSpendStats,
-	});
-
-	watch(query.error, e => {
-		if (e) {
-			showMessage(
-				te(`warnings.${e.message}`) ? t(`warnings.${e.message}`) : e.message,
-				'red-darken-3'
-			);
-		}
-	});
-
-	return query;
+	return useQuery(categoriesSpendStatsQuery);
 });
+
+export function useCategoriesSpendStatsQueryState() {
+	return useQueryState(categoriesSpendStatsQuery.key);
+}

--- a/src/queries/currency.ts
+++ b/src/queries/currency.ts
@@ -18,6 +18,9 @@ export const useCurrencyQuery = defineQuery(() => {
 		meta: {
 			errorMessage: e =>
 				te(`warnings.${e.message}`) ? t(`warnings.${e.message}`) : t('error_loading_currency'),
+			onError: () => {
+				userStore.resetUserCurrency();
+			},
 		},
 	}));
 

--- a/src/queries/currency.ts
+++ b/src/queries/currency.ts
@@ -1,12 +1,10 @@
 import { fetchCurrency } from '@/api/currency';
 import type { UserInfo } from '@/api/user';
-import { useSnackbarStore } from '@/stores/snackbar';
 import { useUserStore } from '@/stores/user';
 import { defineQuery, defineQueryOptions, useQuery, useQueryState } from '@pinia/colada';
-import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-const currencyQuery = defineQueryOptions((currency: UserInfo['currency']) => ({
+export const currencyQuery = defineQueryOptions((currency: UserInfo['currency']) => ({
 	key: ['currency', currency],
 	query: () => fetchCurrency(currency),
 }));
@@ -14,19 +12,14 @@ const currencyQuery = defineQueryOptions((currency: UserInfo['currency']) => ({
 export const useCurrencyQuery = defineQuery(() => {
 	const userStore = useUserStore();
 	const { t, te } = useI18n({ useScope: 'global' });
-	const { showMessage } = useSnackbarStore();
 
-	const query = useQuery(() => currencyQuery(userStore.userCurrency));
-
-	watch(query.error, e => {
-		if (e) {
-			showMessage(
+	const query = useQuery(() => ({
+		...currencyQuery(userStore.userCurrency),
+		meta: {
+			errorMessage: e =>
 				te(`warnings.${e.message}`) ? t(`warnings.${e.message}`) : t('error_loading_currency'),
-				'red-darken-3'
-			);
-			userStore.resetUserCurrency();
-		}
-	});
+		},
+	}));
 
 	return query;
 });

--- a/src/queries/record.ts
+++ b/src/queries/record.ts
@@ -1,34 +1,25 @@
 import { fetchRecordById, fetchRecordsWithCategory, type Record } from '@/api/record';
-import { useSnackbarStore } from '@/stores/snackbar';
 import { defineQuery, useQuery } from '@pinia/colada';
 import { useRouteQuery } from '@vueuse/router';
 import { defaultRecordsPerPage } from '@/constants/app';
-import { watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
 export const useRecordByIdQuery = defineQuery(() => {
 	const { t } = useI18n({ useScope: 'global' });
-	const { showMessage } = useSnackbarStore();
 	const route = useRoute('//records/[id]');
 
-	const query = useQuery({
+	return useQuery({
 		key: () => ['record', { id: route.params.id }],
 		query: () => fetchRecordById(route.params.id),
+		meta: {
+			errorMessage: () => t('no_record_found'),
+		},
 	});
-
-	watch(query.error, e => {
-		if (e) {
-			showMessage(t('no_record_found'), 'red-darken-3');
-		}
-	});
-
-	return query;
 });
 
 export const useRecordsWithCategoryQuery = defineQuery(() => {
 	const { t } = useI18n({ useScope: 'global' });
-	const { showMessage } = useSnackbarStore();
 
 	// Init Records table pagination and sorting
 	const page = useRouteQuery<string, number>('page', '1', {
@@ -77,12 +68,9 @@ export const useRecordsWithCategoryQuery = defineQuery(() => {
 			return { records, totalRecords: count || records.length };
 		},
 		placeholderData: previousData => previousData ?? { records: [], totalRecords: 0 },
-	});
-
-	watch(query.error, e => {
-		if (e) {
-			showMessage(t('error_loading_records_or_categories'), 'red-darken-3');
-		}
+		meta: {
+			errorMessage: () => t('error_loading_records_or_categories'),
+		},
 	});
 
 	return { ...query, page, perPage, sortKey, sortOrder };

--- a/src/types/i18n-schema.d.ts
+++ b/src/types/i18n-schema.d.ts
@@ -25,3 +25,5 @@ declare module 'vue-i18n' {
 		};
 	}
 }
+
+export {};

--- a/src/types/pinia-colada.d.ts
+++ b/src/types/pinia-colada.d.ts
@@ -1,7 +1,10 @@
+import type { UseQueryEntry } from '@pinia/colada';
+
 declare module '@pinia/colada' {
 	interface TypesConfig {
 		queryMeta: {
 			errorMessage?: (err: Error) => string | string;
+			onError?: (err: Error, entry: UseQueryEntry) => void;
 		};
 	}
 }

--- a/src/types/pinia-colada.d.ts
+++ b/src/types/pinia-colada.d.ts
@@ -1,0 +1,9 @@
+declare module '@pinia/colada' {
+	interface TypesConfig {
+		queryMeta: {
+			errorMessage?: (err: Error) => string | string;
+		};
+	}
+}
+
+export {};


### PR DESCRIPTION
This pull request refactors how error handling is managed for queries and mutations, centralizing and standardizing error messages and side effects across the app. Instead of handling errors in each query with local watchers and snackbar calls, a global Pinia Colada plugin now handles query errors, using metadata for error messages and side effects. This improves maintainability and consistency of error handling. Additionally, queries and mutations now use shared query option objects for better reusability and type safety.

**Centralized error handling and plugin improvements:**

- Introduced a global `PiniaColadaQueryErrorHandlingPlugin` in `src/plugins/pinia-colada.ts` that listens for query errors and displays appropriate error messages using the i18n system and the snackbar store. This plugin is now registered with Pinia Colada, replacing local error handling in individual queries.
**Query and mutation refactoring:**

- Refactored category, currency, and record queries to use shared query option objects (e.g., `categoriesQuery`, `currencyQuery`) and moved error message logic into the `meta` field of each query, removing redundant local error watchers and snackbar usage. 
- Updated category mutation logic to use the new query key constants from `categoriesQuery` for cache updates, invalidation, and rollback, improving reliability and reducing duplication. 
**Code cleanup and maintainability:**

- Removed unnecessary imports and local error handling logic from query files, resulting in cleaner and more maintainable code. 

These changes make error handling more robust, reduce code duplication, and ensure a consistent user experience across the application.