### PR TITLE
feat: load turnstile script using `unhead` `useScript()`, create `CfTurnstile` component to render turnstile

### DIFF
--- a/src/components/auth/CfTurnstile.vue
+++ b/src/components/auth/CfTurnstile.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+/// <reference types="@types/cloudflare-turnstile" />
+import { useScriptCloudflareTurnstile } from '@/composables/turnstile';
+import { ref, onBeforeUnmount, useTemplateRef } from 'vue';
+
+const {
+	tag = 'div',
+	options = {},
+	resetInterval = 1000 * 250,
+} = defineProps<{
+	tag?: keyof HTMLElementTagNameMap;
+	options?: Omit<Partial<Turnstile.RenderParameters>, 'callback'>;
+	resetInterval?: number;
+}>();
+
+const token = defineModel<string>();
+
+const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+
+const elRef = useTemplateRef<HTMLElement>('el');
+const unmountStarted = ref(false);
+let id: string | undefined | null = undefined;
+let interval: ReturnType<typeof setInterval>;
+
+const { onLoaded } = useScriptCloudflareTurnstile();
+
+let _reset: Turnstile.Turnstile['reset'];
+let remove: Turnstile.Turnstile['remove'];
+
+const reset = () => {
+	if (id) {
+		_reset(id);
+	}
+};
+
+const unmount = () => {
+	unmountStarted.value = true;
+	clearInterval(interval);
+
+	if (id) {
+		remove(id);
+	}
+};
+
+onLoaded(async ({ render, reset: resetFn, remove: removeFn }) => {
+	if (!elRef.value) {
+		return;
+	}
+	_reset = resetFn;
+	remove = removeFn;
+	id = render(elRef.value, {
+		sitekey: siteKey,
+		callback: (_token: string) => (token.value = _token),
+		...options,
+	});
+	interval = setInterval(reset, resetInterval);
+
+	if (unmountStarted.value) {
+		unmount();
+	}
+});
+
+onBeforeUnmount(unmount);
+
+defineExpose({ reset });
+</script>
+
+<template>
+	<component :is="tag" ref="el" />
+</template>

--- a/src/components/auth/LocalRegister.vue
+++ b/src/components/auth/LocalRegister.vue
@@ -43,7 +43,7 @@
 			</template>
 		</v-checkbox>
 
-		<div class="cf-turnstile"></div>
+		<CfTurnstile v-model="turnstileToken" />
 
 		<v-btn
 			:text="$t('sign_in')"
@@ -58,11 +58,11 @@
 <script setup lang="ts">
 import PassField from '@/components/ui/PassField.vue';
 import LocalizedInput from '@/components/ui/LocalizedInput.vue';
+import CfTurnstile from '@/components/auth/CfTurnstile.vue';
 import { ref, useTemplateRef } from 'vue';
 import { mdiSend } from '@mdi/js';
 import { register } from '@/api/auth';
 import { user as validations } from '@/utils/validations';
-import { useTurnstile } from '@/composables/turnstile';
 import { validateToken } from '@/api/turnstile';
 import { useDisplay } from 'vuetify';
 
@@ -72,8 +72,8 @@ const emit = defineEmits<{
 }>();
 
 const { xs } = useDisplay();
-const turnstileToken = useTurnstile('.cf-turnstile');
 
+const turnstileToken = ref('');
 const formRef = useTemplateRef('form');
 const loading = ref(false);
 const formState = ref({

--- a/src/composables/turnstile.ts
+++ b/src/composables/turnstile.ts
@@ -1,49 +1,21 @@
-import { ref, toValue, type MaybeRefOrGetter, onMounted, onUnmounted } from 'vue';
-import { useScriptTag } from '@vueuse/core';
-
-const sitekey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
-
-export const useTurnstile = (selector: MaybeRefOrGetter<string | HTMLElement>) => {
-	let turnstileId: string | null = null;
-
-	const turnstileToken = ref('');
-
-	const { load, unload } = useScriptTag(
-		`${import.meta.env.VITE_TURNSTILE_SCRIPT_SRC}?render=explicit&onload=onloadTurnstileCallback`,
-		// on script tag loaded.
-		() => {
-			window.onloadTurnstileCallback = () => {
-				turnstileId =
-					turnstile.render(toValue(selector), {
-						sitekey,
-						size: 'normal',
-						'refresh-expired': 'manual',
-						theme: 'auto',
-						callback: token => {
-							turnstileToken.value = token;
-						},
-					}) ?? null;
-			};
-		},
-		{ defer: true, manual: true }
-	);
-
-	onMounted(() => {
-		load();
-	});
-
-	onUnmounted(() => {
-		if (turnstileId) {
-			turnstile.remove(turnstileId);
-		}
-		unload();
-	});
-
-	return turnstileToken;
-};
+/// <reference types="@types/cloudflare-turnstile" />
+import { useScript, type UseScriptOptions } from '@unhead/vue';
 
 declare global {
 	interface Window {
+		// @types/cloudflare-turnstile doesn't provide full api
+		turnstile: Turnstile.Turnstile;
 		onloadTurnstileCallback: () => void;
 	}
+}
+
+const scriptSrc =
+	import.meta.env.VITE_TURNSTILE_SCRIPT_SRC ||
+	'https://challenges.cloudflare.com/turnstile/v0/api.js';
+
+export function useScriptCloudflareTurnstile(options?: UseScriptOptions<Turnstile.Turnstile>) {
+	return useScript<Turnstile.Turnstile>(scriptSrc, {
+		use: () => window.turnstile,
+		...options,
+	});
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,7 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		"types": ["@types/cloudflare-turnstile", "@intlify/unplugin-vue-i18n/messages"]
+		"types": ["@intlify/unplugin-vue-i18n/messages"]
 	},
 	"vueCompilerOptions": {
 		"plugins": ["vue-router/volar/sfc-typed-router", "vue-router/volar/sfc-route-blocks"]


### PR DESCRIPTION
This pull request refactors how Cloudflare Turnstile CAPTCHA is integrated into the authentication flow. The main change is the introduction of a dedicated `CfTurnstile` Vue component, replacing the previous composable-based approach. This improves modularity, maintainability, and flexibility for CAPTCHA rendering and lifecycle management.

**Cloudflare Turnstile Integration Refactor**

*Componentization and Usage:*
- Introduced a new `CfTurnstile` Vue component that encapsulates Turnstile rendering, token management, and reset logic, replacing the previous inline `.cf-turnstile` div and composable usage. The component uses the Cloudflare Turnstile API directly and exposes a `reset` method. 
- Updated `LocalRegister.vue` to use the new `CfTurnstile` component with `v-model` for token binding, removing the old `.cf-turnstile` div and related composable logic. 

*Composable and Script Loading:*
- Replaced the old `useTurnstile` composable with a new `useScriptCloudflareTurnstile` composable, leveraging `@unhead/vue`'s `useScript` for improved script loading and Turnstile API access.

*TypeScript Configuration:*
- Removed the global inclusion of `@types/cloudflare-turnstile` from `tsconfig.app.json` since type references are now managed locally within relevant files. 