### PR TITLE
fix: do not wrap store states in `readonly`

### DIFF
--- a/src/stores/snackbar.ts
+++ b/src/stores/snackbar.ts
@@ -1,5 +1,5 @@
 import { defineStore, acceptHMRUpdate } from 'pinia';
-import { readonly, shallowRef } from 'vue';
+import { shallowRef } from 'vue';
 
 export interface Snackbar {
 	text: string;
@@ -18,7 +18,7 @@ export const useSnackbarStore = defineStore('snackbar', () => {
 		snackbar.value = { text, color, timeout };
 	};
 
-	return { snackbar: readonly(snackbar), showMessage };
+	return { snackbar, showMessage };
 });
 
 if (import.meta.hot) {

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,5 +1,5 @@
 import { defineStore, acceptHMRUpdate } from 'pinia';
-import { computed, readonly, shallowRef } from 'vue';
+import { computed, shallowRef } from 'vue';
 import { serverCurrency } from '@/constants/currency';
 import { defaultLocale, localeKey } from '@/constants/i18n';
 import type { UserInfo } from '@/api/user';
@@ -28,7 +28,7 @@ export const useUserStore = defineStore('user', () => {
 	};
 
 	return {
-		info: readonly(info),
+		info,
 		userCurrency,
 		setInfo,
 		setLocale,


### PR DESCRIPTION
Making state properties readonly will break SSR, devtools, and other plugins according to https://github.com/vuejs/pinia/discussions/2756#discussioncomment-10503566

This pull request updates the Pinia stores for `snackbar` and `user` by removing the use of Vue's `readonly` wrapper from their exposed state. Now, the `snackbar` and `info` state objects are returned directly, which allows components to modify them if needed.