### PR TITLE
chore(renovate): opt-out from `:pinDevDependencies` in config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
 		"config:recommended",
 		":maintainLockFilesWeekly",
 		":widenPeerDependencies",
-		":pinDevDependencies",
 		":semanticCommitTypeAll(chore)",
 		"group:allNonMajor"
 	],


### PR DESCRIPTION
This pull request makes a small configuration change to the Renovate bot settings. The rule for pinning dev dependencies has been removed, which means dev dependencies will no longer be automatically pinned to specific versions.